### PR TITLE
Add Playwright Test for Client Work Verification

### DIFF
--- a/tests/verify_client_work.spec.ts
+++ b/tests/verify_client_work.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+
+test('Verify Client Work Page', async ({ page }) => {
+  // Step 1: Navigate to https://www.epam.com/
+  await page.goto('https://www.epam.com/');
+
+  // Step 2: Select "Services" from the header menu
+  await page.click('header >> text=Services');
+
+  // Step 3: Click the "Explore Our Client Work" link
+  await page.click('text=Explore Our Client Work');
+
+  // Step 4: Verify that the "Client Work" text is visible on the page
+  const clientWorkText = await page.locator('text=Client Work');
+  await expect(clientWorkText).toBeVisible();
+});


### PR DESCRIPTION
This PR adds a Playwright test to verify the "Client Work" page on the EPAM website. The test performs the following steps:

1. Navigates to https://www.epam.com/
2. Selects "Services" from the header menu.
3. Clicks the "Explore Our Client Work" link.
4. Verifies that the "Client Work" text is visible on the page.